### PR TITLE
Create crd

### DIFF
--- a/api/v1/markdownview_types.go
+++ b/api/v1/markdownview_types.go
@@ -28,18 +28,37 @@ type MarkdownViewSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of MarkdownView. Edit markdownview_types.go to remove/update
-	Foo string `json:"foo,omitempty"`
+	// Markdowns contain the markdown files you want to display.
+	// The key indicates the file name and must not overlap with the keys.
+	// The value is the content in markdown format.
+	//+kubebuilder:validation:Required
+	//+kubebuilder:validation:MinProperties=1
+	Markdowns map[string]string `json:"markdowns,omitempty"`
+
+	// Replicas is the number of viewers.
+	// +kubebuilder:default=1
+	// +optional
+	Replicas int32 `json:"replicas,omitempty"`
+
+	// ViewerImage is the image name of the viewer.
+	// +optional
+	ViewerImage string `json:"viewerImage,omitempty"`
 }
 
 // MarkdownViewStatus defines the observed state of MarkdownView
-type MarkdownViewStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-}
+//+kubebuilder:validation:Enum=NotReady;Available;Healthy
+type MarkdownViewStatus string
+
+const (
+	MarkdownViewNotReady  = MarkdownViewStatus("NotReady")
+	MarkdownViewAvailable = MarkdownViewStatus("Available")
+	MarkdownViewHealthy   = MarkdownViewStatus("Healthy")
+)
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="REPLICAS",type="integer",JSONPath=".spec.replicas"
+//+kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status"
 
 // MarkdownView is the Schema for the markdownviews API
 type MarkdownView struct {

--- a/config/crd/bases/view.kumashun8.github.io_markdownviews.yaml
+++ b/config/crd/bases/view.kumashun8.github.io_markdownviews.yaml
@@ -15,7 +15,14 @@ spec:
     singular: markdownview
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.replicas
+      name: REPLICAS
+      type: integer
+    - jsonPath: .status
+      name: STATUS
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: MarkdownView is the Schema for the markdownviews API
@@ -35,14 +42,30 @@ spec:
           spec:
             description: MarkdownViewSpec defines the desired state of MarkdownView
             properties:
-              foo:
-                description: Foo is an example field of MarkdownView. Edit markdownview_types.go
-                  to remove/update
+              markdowns:
+                additionalProperties:
+                  type: string
+                description: Markdowns contain the markdown files you want to display.
+                  The key indicates the file name and must not overlap with the keys.
+                  The value is the content in markdown format.
+                minProperties: 1
+                type: object
+              replicas:
+                default: 1
+                description: Replicas is the number of viewers.
+                format: int32
+                type: integer
+              viewerImage:
+                description: ViewerImage is the image name of the viewer.
                 type: string
             type: object
           status:
             description: MarkdownViewStatus defines the observed state of MarkdownView
-            type: object
+            enum:
+            - NotReady
+            - Available
+            - Healthy
+            type: string
         type: object
     served: true
     storage: true

--- a/config/samples/view_v1_markdownview.yaml
+++ b/config/samples/view_v1_markdownview.yaml
@@ -3,4 +3,14 @@ kind: MarkdownView
 metadata:
   name: markdownview-sample
 spec:
-  # TODO(user): Add fields here
+  markdowns:
+    SUMMARY.md: |
+      # Summary
+
+      - [Page1](page1.md)
+    page1.md: |
+      # Page 1
+
+      一ページ目のコンテンツです。
+  replicas: 1
+  viewerImage: "peaceiris/mdbook:latest"


### PR DESCRIPTION
## 概要

https://zoetrope.github.io/kubebuilder-training/controller-tools/crd.html

```
❯ make uninstall & make install

❯ k apply -f config/samples/view_v1_markdownview.yaml
markdownview.view.kumashun8.github.io/markdownview-sample created

❯ k get markdownview markdownview-sample -o yaml
apiVersion: view.kumashun8.github.io/v1
kind: MarkdownView
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"view.kumashun8.github.io/v1","kind":"MarkdownView","metadata":{"annotations":{},"name":"markdownview-sample","namespace":"default"},"spec":{"markdowns":{"SUMMARY.md":"# Summary\n\n- [Page1](page1.md)\n","page1.md":"# Page 1\n\n一ページ目のコンテンツです。\n"},"replicas":1,"viewerImage":"peaceiris/mdbook:latest"}}
  creationTimestamp: "2022-02-02T16:48:06Z"
  generation: 1
  managedFields:
  - apiVersion: view.kumashun8.github.io/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .: {}
          f:kubectl.kubernetes.io/last-applied-configuration: {}
      f:spec:
        .: {}
        f:markdowns:
          .: {}
          f:SUMMARY.md: {}
          f:page1.md: {}
        f:replicas: {}
        f:viewerImage: {}
    manager: kubectl
    operation: Update
    time: "2022-02-02T16:48:06Z"
  name: markdownview-sample
  namespace: default
  resourceVersion: "16165"
  uid: 9ea680d5-53cf-4b02-b50f-90f37dc1b726
spec:
  replicas: 1

```